### PR TITLE
Revert "Fixed issues and added packages"

### DIFF
--- a/Dockerfile.tensorflow-cpu
+++ b/Dockerfile.tensorflow-cpu
@@ -69,7 +69,7 @@ RUN conda config --system --set channel_priority false && \
     'cython' \
     'dask' \
     'dill' \
-    'h5py==2.10.0' \
+    'h5py' \
     'ipywidgets' \
     'ipympl'\
     'matplotlib-base' \
@@ -89,8 +89,6 @@ RUN conda config --system --set channel_priority false && \
     'vincent' \
     'widgetsnbextension'\
     'xlrd' \
-    'opencv' \
-    'kaggle' \
     && \
     conda clean --all -f -y && \
     jupyter notebook --generate-config && \


### PR DESCRIPTION
Reverts lehrig/kubeflow-ppc64le-images#1

Turns out that the build becomes unstable with this (Step 13/24 is stuck without error message, last info message "Writing default config to: /home/jovyan/.jupyter/jupyter_notebook_config.py").